### PR TITLE
fix: rename trusted issuer

### DIFF
--- a/449805c83e13f332b1b35eac6ffa93187fbd1c648085.json
+++ b/449805c83e13f332b1b35eac6ffa93187fbd1c648085.json
@@ -18,7 +18,7 @@
             },
             "trusted_issuers": {
                 "ba49b559f93fc7c80b3729d47edd7c37d034803ac93c": {
-                    "name": "testIdp",
+                    "name": "Jans",
                     "description": "testIdp",
                     "openid_configuration_endpoint": "https://test-jans.gluu.info/.well-known/openid-configuration",
                     "token_metadata": {


### PR DESCRIPTION
Rename trusted issuer to conform with new authz system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated trusted issuer configuration name from 'testIdp' to 'Jans'.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->